### PR TITLE
Wip dedication and consent

### DIFF
--- a/app/controllers/dedications_controller.rb
+++ b/app/controllers/dedications_controller.rb
@@ -2,4 +2,8 @@ class DedicationsController < ApplicationController
     def show
         @dedication = Dedication.find(params[:id])
     end
+    
+    def edit
+        @dedication = Dedication.find(params[:id])
+    end
 end

--- a/app/views/dedications/edit.html.haml
+++ b/app/views/dedications/edit.html.haml
@@ -1,0 +1,13 @@
+%h1 Dedication and Consent Form for Digital Wall of Founders
+
+%h2 Dedication
+%h3 Write a Dedication for your Donation
+%p= text_area_tag "dedication"
+
+%h2 Digital Wall of Founders
+
+.inline-field
+  %input#checkbox{:type => "checkbox"}/
+  %label{:for => "checkbox"} I want my dedication to appear on the Digital Wall of Founders
+
+%p= button_tag "Submit"

--- a/app/views/dedications/show.html.haml
+++ b/app/views/dedications/show.html.haml
@@ -1,7 +1,8 @@
-%h1 "#{@dedication.hospital.name}}"
-%h1 "#{@dedication.donor.first_name} #{@dedication.donor.last_name}"
+%h1 #{@dedication.hospital.name}
+%h1 #{@dedication.donor.first_name} #{@dedication.donor.last_name}
 
 %p= link_to "#{@dedication.id}", hospital_path(@dedication.hospital.name)
+%p= link_to "Edit", edit_donor_dedication_path(@dedication.donor_id, @dedication.id)
 
 %ul#dedication_info
     %li
@@ -14,7 +15,7 @@
         Dedication:
         = @dedication.dedication
 
-%h1 "Permalink"
+%h1 Permalink
 %p= link_to "Twitter", ""
 %p= link_to "Facebook", ""
         

--- a/app/views/hospitals/show.html.haml
+++ b/app/views/hospitals/show.html.haml
@@ -37,13 +37,17 @@
                 });
             }
     %script{:async => "", :defer => "defer", :src => "https://maps.googleapis.com/maps/api/js?key=AIzaSyBTUBDqxJw2PidgRgXPJg_p84LCVS026l8&callback=initMap"}
+    
 
 - ["Platinum", "Gold", "Silver"].each do |tier|
-    %h2 #{tier}
+    %a{:href => "##{tier}"} #{tier}
+    
+- ["Platinum", "Gold", "Silver"].each do |tier|
+    %h2{:id => "#{tier}"} #{tier}
     - Dedication.where(:hospital => @hospital.id, :tier => tier, :status => true).each do |dedication|
         %div{:class => "dedication", :id => dedication.id} 
             = link_to "#{dedication.donor.first_name} #{dedication.donor.last_name}",
                       donor_path(Donor.find(dedication.donor_id))
                   
-            {#{dedication.dedication}}
+            "#{dedication.dedication}"
             = link_to "View", hospital_dedication_path(@hospital, dedication), :id => "view_#{dedication.id}"

--- a/features/step_definitions/submit_dedication_and_consent_steps.rb
+++ b/features/step_definitions/submit_dedication_and_consent_steps.rb
@@ -1,3 +1,0 @@
-Given /^my donor id is (.*)$/ do |id|
-    pending
-end

--- a/features/submit_dedication_and_consent.feature
+++ b/features/submit_dedication_and_consent.feature
@@ -6,8 +6,7 @@ Background:
   And the following donors exist
     | id | first_name | last_name  | email | phone |
     | 1  | John | Smith | jsmith@gmail.com | 123-456-7890 |
-  And I am on the submit dedication page
-  And my donor id is 1
+  And I am on the submit dedication page with donor id 1
 
 Scenario: After making a donation, I should see a form to enter my dedication and submit my consent
   Then I should see "My Dedication"

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -26,8 +26,9 @@ module NavigationHelpers
       donor_dedication_path(Donor.where(:first_name => $1.split[0], 
       :last_name => $1.split[1]).pluck(:id)[0], Dedication.find($2))
     
-    when /^the submit dedication page$/
-      '/' #will replace with proper link in iter 2-2
+    when /^the submit dedication page with donor id (.*)$/
+#      edit_hopsital_dedication_path($1, )
+      '/'
       
     # Add more mappings here.
     # Here is an example that pulls values out of the Regexp:


### PR DESCRIPTION
Anchoring links up.

Basic (incomplete/nonfunctional) consent form page up, accessed through "Edit" link on each individual dedication page - temporary location until link generation is figured out.